### PR TITLE
fix: #13/MyFavoriteCard를 기존의 TeamCard로 변경 및 그리드 변경

### DIFF
--- a/src/components/MyFavorites/myFavorites.js
+++ b/src/components/MyFavorites/myFavorites.js
@@ -1,28 +1,16 @@
 import { TeamButton, TeamMemberButton, CardContainter } from "./styles";
 
-import MyFavoriteCard from "../MyPageCard/MyFavoriteCard/myFavoriteCard";
-import MyTeamTestData from "../../api/myTeamTestData";
+import TeamCard from "../Card/teamCard";
+import teamTestData from "../../api/teamTestData";
 
 const MyFavorites = (props) => {
-  var d = {
-    id: 1,
-    name: "홍길동",
-    position: "프론트엔드 개발자",
-    gender: "남성",
-    location: "서울",
-    introduction:
-      "React와 JavaScript 경험이 있는 열정적인 프론트엔드 개발자입니다.",
-    skill1: "React",
-    skill2: "JavaScript",
-  };
-
   return (
     <div>
       <TeamButton>팀</TeamButton>
       <TeamMemberButton>팀원</TeamMemberButton>
       <CardContainter>
-        {MyTeamTestData.map((item) => (
-          <MyFavoriteCard data={item} />
+        {teamTestData.map((item) => (
+          <TeamCard data={item} />
         ))}
       </CardContainter>
     </div>

--- a/src/components/MyFavorites/styles.js
+++ b/src/components/MyFavorites/styles.js
@@ -32,14 +32,15 @@ export const TeamMemberButton = styled.button`
 `;
 
 export const CardContainter = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 52px 26px;
   position: absolute;
   transform: translateX(-50%);
   left: 50%;
-  top: 250px;
+  top: 200px;
   width: 767px;
   height: 600px;
-  display: flex;
-  flex-wrap: wrap;
   gap: 20px;
   overflow-y: auto;
 `;


### PR DESCRIPTION
## Overview

MyFavoriteCard를 기존의 TeamCard로 변경 및 그리드 변경
### Related Issue

Issue Number : #13
## Task Details

- MyFavoriteCard를 기존의 TeamCard로 컴포넌트 변경
- TeamCard를 감싸는 레이아웃 그리드로 변경
- 테스트 데이터셋 기존이 것으로 변경

## Screenshots (Optional)
![localhost_3000_mypage_favorites(1920x1080) (1)](https://github.com/Alpha-e-Um/Frontend/assets/52407470/b3b333ec-1bc0-49a9-a44a-df1f5a0b7c25)


