### PR TITLE
사이드 네비게이션 컴포넌트화

### DIFF
--- a/src/components/SideNavigation/sideNavigation.js
+++ b/src/components/SideNavigation/sideNavigation.js
@@ -14,19 +14,46 @@ import {
 import { jobCategories } from "./jobPosition";
 
 const SideNavigation = () => {
-  const [sectionEnabled, setSectionEnabled] = useState({
-    design: false,
-    development: false,
-    planning: false,
-    media: false,
-    marketing: false,
-    translation: false,
-    other: false,
-  });
-  const [subCategoryEnabled, setSubCategoryEnabled] = useState({});
+  const initialMainCategoryStates = jobCategories.reduce((acc, category) => {
+    acc[category.kind] = true;
+    return acc;
+  }, {});
 
-  const handleSectionCheckbox = (section) => {
-    setSectionEnabled((prev) => ({ ...prev, [section]: !prev[section] }));
+  const initialSubCategoryStates = jobCategories.reduce((acc, category) => {
+    acc[category.kind] = new Array(category.subCategories.length).fill(true);
+    return acc;
+  }, {});
+
+  const [mainCategoryStates, setMainCategoryStates] = useState(
+    initialMainCategoryStates,
+  );
+  const [subCategoryStates, setSubCategoryStates] = useState(
+    initialSubCategoryStates,
+  );
+
+  const handleMainCategoryCheckbox = (kind) => {
+    var futureStateOfMain = !mainCategoryStates[kind];
+    // 서브카테고리은 메인카테고리가 변경될 값으로 전부 따라감
+    setMainCategoryStates((prev) => ({ ...prev, [kind]: !prev[kind] }));
+    setSubCategoryStates((prev) => ({
+      ...prev,
+      [kind]: prev[kind].fill(futureStateOfMain),
+    }));
+  };
+
+  const handleSubCategoryCheckbox = (kind, index) => {
+    var temp = subCategoryStates[kind];
+    temp[index] = !temp[index];
+    if (!temp[index]) {
+      // 서브 카테고리중 1개라도 체크를 해제하면, 메인카테고리도 체크 해제 되야함
+      setMainCategoryStates((pres) => ({ ...pres, [kind]: false }));
+    }
+    setSubCategoryStates((prev) => ({ ...prev, [kind]: temp }));
+  };
+
+  const filterReset = () => {
+    setMainCategoryStates(initialMainCategoryStates);
+    setSubCategoryStates(initialSubCategoryStates);
   };
 
   return (
@@ -34,17 +61,9 @@ const SideNavigation = () => {
       <NavHeader>
         <Title>필터</Title>
         <ResetButton
-          onClick={() =>
-            setSectionEnabled({
-              design: false,
-              development: false,
-              planning: false,
-              media: false,
-              marketing: false,
-              translation: false,
-              other: false,
-            })
-          }
+          onClick={() => {
+            filterReset();
+          }}
         >
           초기화
         </ResetButton>
@@ -60,13 +79,15 @@ const SideNavigation = () => {
       >
         모집 기간
       </Title>
+
+      {/* 직종 분류 섹션 */}
       <Title style={{ textAlign: "left" }}>직종 분류</Title>
       {jobCategories.map((category) => (
         <Section key={category.mainCategory}>
           <SectionTitleRow>
             <Checkbox
-              checked={sectionEnabled[category.kind]}
-              onChange={() => handleSectionCheckbox(category.kind)}
+              checked={mainCategoryStates[category.kind]}
+              onChange={() => handleMainCategoryCheckbox(category.kind)}
             />
             <SectionTitle>{category.mainCategory}</SectionTitle>
           </SectionTitleRow>
@@ -74,9 +95,13 @@ const SideNavigation = () => {
             {category.subCategories.map((subCategory, index) => (
               <Item key={index}>
                 <Checkbox
-                  disabled={!sectionEnabled[category.kind]}
-                  // checked={subCategoryEnabled[subCategoryName] || false}
-                  // onChange={() => handleSubCategoryCheckbox(subCategoryName)}
+                  checked={
+                    mainCategoryStates[category.kind] ||
+                    subCategoryStates[category.kind][index]
+                  }
+                  onChange={() =>
+                    handleSubCategoryCheckbox(category.kind, index)
+                  }
                 />
                 {subCategory}
               </Item>

--- a/src/components/SideNavigation/styles.js
+++ b/src/components/SideNavigation/styles.js
@@ -32,6 +32,7 @@ export const ResetButton = styled.button`
   cursor: pointer;
   color: #007bff;
   font-size: 1rem;
+  font-weight: 700;
 `;
 
 export const Section = styled.section`


### PR DESCRIPTION
## Overview

> 사이드 네비게이션을 컴포넌트화 하였음. 내부의 데이터만 갈아끼우면 여러곳에서 사용할 수 있음

### Related Issue

Issue Number : #41 

## Task Details

- 사이드 네비게이션이 객체 데이터를 기반으로 UI를 그리도록 함
- 메인 카테고리를 체크하거나 체크 해제하였을 때 서브카테고리도 이를 따라가도록 함
- 서브 카테고리 중 1개라도 체크 해제하면 메인카테고리가 체크 해제되도록 함

## Screenshots (Optional)

> Please provide screenshots of your task if you need.
<img width="300px" src="https://github.com/Alpha-e-Um/Frontend/assets/52407470/e92dbb84-9a92-4ce0-987c-de06fe33c1bf" />
<img width="300px" src="https://github.com/Alpha-e-Um/Frontend/assets/52407470/10cbe293-6e70-49a5-858e-389e9b9a1f0e" />


## Test Scope & Checklist (Optional)

- [ ] 메인 카테고리의 체크 상태에 따라 서브 카테고리의 체크 상태가 바뀌는지
- [ ] 서브 카테고리 중 1개라도 체크가 해제되면 메인 카테고리의 체크상태가 해제되는지
